### PR TITLE
Deployment: Add test droplet for test builds of application.

### DIFF
--- a/.github/workflows/continous-QA-deployment.yml
+++ b/.github/workflows/continous-QA-deployment.yml
@@ -56,8 +56,7 @@ jobs:
         run: >
           ssh $SSH_USER@$SSH_HOST
           -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
-          'export DOCKER_USERNAME=$DOCKER_USERNAME && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
+          'export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }} && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST_TEST }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/continous-QA-deployment.yml
+++ b/.github/workflows/continous-QA-deployment.yml
@@ -1,20 +1,12 @@
 ---
-name: Continuous Deployment
+name: QA Deployment
 
 on:
-  push:
-    # Run workflow every time something is pushed to the main branch
-    #branches:
-    #  - main
-    #  - master
-    
-    # Run workflow every time a new tag is pushed to the main branch
-    tags:
-      - '*'
-
-  # allow manual triggers for now too
+  pull_request:
+    branches:
+      - main
+  # allow manual triggers too
   workflow_dispatch:
-    manual: true
 
 # Remember to set the following secrets in your repository's settings:
 # https://github.com/your_username/itu-minitwit-ci/settings/secrets/actions
@@ -22,7 +14,7 @@ on:
 # DOCKER_PASSWORD
 # SSH_USER
 # SSH_KEY
-# SSH_HOST
+# SSH_HOST_TEST
 
 jobs:
   build:
@@ -39,7 +31,6 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Set up Docker Buildx (for docker compose)
-#        uses: docker/setup-buildx-action@v3
         run: echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
       
       - name: Create .env file for compose
@@ -49,7 +40,7 @@ jobs:
         run: docker compose build && docker compose push
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          IMAGE_NAME: minitwitimage
+          IMAGE_NAME: testminitwit
 
       - name: Configure SSH
         run: |
@@ -66,4 +57,4 @@ jobs:
           'export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }} && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_HOST: ${{ secrets.SSH_HOST_TEST }}

--- a/.github/workflows/continous-QA-deployment.yml
+++ b/.github/workflows/continous-QA-deployment.yml
@@ -34,7 +34,9 @@ jobs:
         run: echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
       
       - name: Create .env file for compose
-        run: echo "API_TOKEN=${{ secrets.API_TOKEN }}" > razor-pages/Web/.env
+        run: echo "API_TOKEN=$API_TOKEN" > razor-pages/Web/.env
+        env:
+          API_TOKEN: ${{ secrets.API_TOKEN }}
       
       - name: Build & push minitwit image
         run: docker compose build && docker compose push
@@ -54,7 +56,8 @@ jobs:
         run: >
           ssh $SSH_USER@$SSH_HOST
           -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
-          'export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }} && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
+          'export DOCKER_USERNAME=$DOCKER_USERNAME && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST_TEST }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/continous-QA-deployment.yml
+++ b/.github/workflows/continous-QA-deployment.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -43,7 +43,9 @@ jobs:
         run: echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
       
       - name: Create .env file for compose
-        run: echo "API_TOKEN=${{ secrets.API_TOKEN }}" > razor-pages/Web/.env
+        run: echo "API_TOKEN=$API_TOKEN" > razor-pages/Web/.env
+        env:
+          API_TOKEN: ${{ secrets.API_TOKEN }}
       
       - name: Build & push minitwit image
         run: docker compose build && docker compose push
@@ -63,7 +65,8 @@ jobs:
         run: >
           ssh $SSH_USER@$SSH_HOST
           -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
-          'export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }} && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
+          'export DOCKER_USERNAME=$DOCKER_USERNAME && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -65,8 +65,7 @@ jobs:
         run: >
           ssh $SSH_USER@$SSH_HOST
           -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
-          'export DOCKER_USERNAME=$DOCKER_USERNAME && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
+          'export DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }} && cd /vagrant && docker compose pull && docker compose up -d --remove-orphans'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ data/
 .secrets
 .vagrant/*
 monitoring/.vagrant/*
+tests/test-droplet/.vagrant/*
 
 # Environment variables
 .env

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   razor-pages:
-    image: ${DOCKER_USERNAME:-local}/minitwitimage:latest
+    image: ${DOCKER_USERNAME:-local}/${IMAGE_NAME:-minitwitimage}:latest
     build:
       context: .
       dockerfile: razor-pages/Dockerfile

--- a/log.md
+++ b/log.md
@@ -36,3 +36,6 @@
 ### Week 7 – DevOps & repo polish (Mar 13 – Mar 19)
 * Chore: split app and monitoring layout; workflow env path for compose.
 * Merged monitoring and restructure branches; added PR template.
+
+### Week 8 - Logging (Mar 20 - Mar 26)
+* Add new droplet for running test-deployments to avoid failing on PROD.

--- a/tests/test-droplet/Vagrantfile
+++ b/tests/test-droplet/Vagrantfile
@@ -1,0 +1,38 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = 'digital_ocean'
+  config.vm.box_url = "https://github.com/devopsgroup-io/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+  config.ssh.private_key_path = '~/.ssh/id_rsa'
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+
+  config.vm.define "webserver-test", primary: false do |server|
+    server.vm.provider :digital_ocean do |provider|
+      provider.ssh_key_name = ENV["SSH_KEY_NAME"]
+      provider.token = ENV["DIGITAL_OCEAN_TOKEN"]
+      provider.image = 'ubuntu-22-04-x64'
+      provider.region = 'fra1'
+      provider.size = 's-1vcpu-1gb'
+      provider.privatenetworking = true
+    end
+
+    server.vm.hostname = "webserver-test"
+
+    server.vm.provision "shell", inline: <<-SHELL
+      set -e
+      # Wait for apt lock (unattended-upgrades often runs on first boot)
+      echo "Waiting for apt to be ready..."
+      for i in $(seq 1 24); do
+        if sudo apt-get update -qq 2>/dev/null; then break; fi
+        echo "  Retry $i/24 in 10s..."
+        sleep 10
+      done
+      sudo apt-get update -qq
+
+      # Install Docker
+      sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io docker-compose-v2
+
+    SHELL
+  end
+end

--- a/tests/test-droplet/Vagrantfile
+++ b/tests/test-droplet/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = 'digital_ocean'
   config.vm.box_url = "https://github.com/devopsgroup-io/vagrant-digitalocean/raw/master/box/digital_ocean.box"
   config.ssh.private_key_path = '~/.ssh/id_rsa'
-  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.synced_folder "../../.", "/vagrant", type: "rsync"
 
   config.vm.define "webserver-test", primary: false do |server|
     server.vm.provider :digital_ocean do |provider|


### PR DESCRIPTION
# Description

This PR adds Vagrantfile for spinning up the webserver-test droplet to be used for test deployments to avoid breaking the production droplet running application.

# Checklist:

- [x] This PR represents one logical change to the codebase
- [x] I have performed a self-review of my own code
- [x] I updated `log.md` and/or `README.md` with relevant usage notes and choice documentation
- [x] **(If deployment/monitoring workflows changed)** Required secrets and env vars are documented; workflow behaviour is as expected
- [x] No secrets, API keys, or credentials are committed (only env examples or placeholders)
