### PR TITLE
Chore: Add mailmap file for all Authors in the git repo 💌

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,13 @@
+Tien <tily@itu.dk> Tien Cam Ly <tily@itu.dk>
+Tien <tily@itu.dk> tienl <tienly197@gmail.com>
+Tien <tily@itu.dk> Tien Cam Ly <tienly197@gmail.com>
+Mie <miejo@itu.dk> Mie Jonasson <jonasson2001@gmail.com>
+Mie <miejo@itu.dk> Mie Jonasson <98812182+Mie-Jonasson@users.noreply.github.com>
+Patrick <ptso@itu.dk> ptso <ptso@itu.dk>
+Mads <orfe@itu.dk> MadsOrfelt <orfe@itu.dk>
+Mads <orfe@itu.dk> Mads Orfelt <118978052+H4xx0r9@users.noreply.github.com>
+Mads <orfe@itu.dk> Mads Orfelt <orfeltmads@gmail.com>
+Krzysztof <krpa@itu.dk> Krzysztof Parocki <kparocki@gmail.com>
+Krzysztof <krpa@itu.dk> kparocki <kparocki@gmail.com>
+Daniel <darh@itu.dk> Daniel <danielring320@gmail.com>
+Daniel <darh@itu.dk> Daniel Ring Hansen <danielring320@gmail.com>

--- a/log.md
+++ b/log.md
@@ -64,3 +64,6 @@
 * Implemented SonarQube's security recommendation to not expand secrets inside run blocks, instead expanding it in an environment block and referencing that in the run. 
 * Changed CI/CD workflow to handle the Docker Swarm changes. 
 * **Simulator `latest` counter:** Dropped the in-memory static field; the value now lives in Postgres (`SimulatorLatest`, one row, `latest_id`, EF migration). Endpoints read and update that row, so it survives restarts and stays shared when several instances talk to the same database.
+
+### Week 13 (May 1 - May 6)
+* Added `.mailmap` file to consolidate authors into persons


### PR DESCRIPTION
# Description

This PR adds the mailmap file as described in [Msc_lecture_notes](https://github.com/itu-devops/MSc_lecture_notes/blob/master/REPORT.md#21-create-a-mailmap-file-in-the-root-of-your-repositories) consolidating authors to actual persons.

Before:
```
jonasson@MacBook-Air-tilhrende-Mie MiniTwit % git shortlog -sne
   124  Tien Cam Ly <tily@itu.dk>
    93  Mie Jonasson <jonasson2001@gmail.com>
    53  ptso <ptso@itu.dk>
    16  MadsOrfelt <orfe@itu.dk>
     8  Mie Jonasson <98812182+Mie-Jonasson@users.noreply.github.com>
     7  Krzysztof Parocki <kparocki@gmail.com>
     5  tienl <tienly197@gmail.com>
     4  Daniel <danielring320@gmail.com>
     4  Daniel Ring Hansen <danielring320@gmail.com>
     4  Tien Cam Ly <tienly197@gmail.com>
     4  kparocki <kparocki@gmail.com>
     3  Mads Orfelt <118978052+H4xx0r9@users.noreply.github.com>
     1  Mads Orfelt <orfeltmads@gmail.com>
```
After:
```
jonasson@MacBook-Air-tilhrende-Mie MiniTwit % git shortlog -sne                                                                   
   133  Tien <tily@itu.dk>
   101  Mie <miejo@itu.dk>
    53  Patrick <ptso@itu.dk>
    20  Mads <orfe@itu.dk>
    11  Krzysztof <krpa@itu.dk>
     8  Daniel <darh@itu.dk>
```

# Checklist:

- [x] This PR represents one logical change to the codebase
- [x] I have performed a self-review of my own code
- [x] I updated `log.md` and/or `README.md` with relevant usage notes and choice documentation
- [x] No secrets, API keys, or credentials are committed (only env examples or placeholders)
