### PR TITLE
deploy/add static analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ c-sharp-code-formatter:
 	dotnet format --verify-no-changes razor-pages/Core/
 
 hadolint-docker-linter: # runs as a docker container itself
-	printf "\n\n Running Docker linter...\n" && \
+	printf "\n\n Running Docker linter tests...\n" && \
 	DOCKERFILES="$$(find . -type f \( -name 'Dockerfile' -o -name 'Dockerfile-*' -o -name '*.Dockerfile' \) -not -path './.git/*')" && \
 	if [ -z "$$DOCKERFILES" ]; then \
 		echo "No Dockerfiles found."; \
@@ -111,11 +111,15 @@ hadolint-docker-linter: # runs as a docker container itself
 		cat "$$dockerfile" | docker run --rm -i hadolint/hadolint; \
 	done
 
-meziantou-c-sharp-analyzer:
-
+roslynator-c-sharp-analyzer: # change --severity-level to "info" to get more diagnostics
+	printf "\n\nRunning C# analyzer tests...\n" && \
+	dotnet tool install -g roslynator.dotnet.cli
+	roslynator analyze razor-pages/Core/Core.csproj --severity-level warning
+	roslynator analyze razor-pages/Infrastructure/Infrastructure.csproj --severity-level warning
+	roslynator analyze razor-pages/Web/Web.csproj --severity-level warning
 
 test-all: test-ui-selenium test-api-simulator
-lint-all: spell-checker c-sharp-code-formatter meziantou-c-sharp-analyzer hadolint-docker-linter
+lint-all: spell-checker c-sharp-code-formatter roslynator-c-sharp-analyzer hadolint-docker-linter
 run-all-validations: test-all lint-all
 
 build-and-test: # requires API_TOKEN to be set in environment variable API_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -87,20 +87,35 @@ test-ui-selenium:
 	cd tests/selenium && \
 	docker compose up --build --abort-on-container-exit --exit-code-from tests
 
-lint-spell-checker:
+spell-checker:
 	printf "\n\nRunning spell checker tests...\n" && \
 	pip install codespell && \
 	cd razor-pages && \
 	codespell
 
-lint-c-sharp:
+c-sharp-code-formatter:
 	printf "\n\nRunning C# linting tests...\n" && \
 	dotnet format --verify-no-changes razor-pages/Infrastructure/ && \
 	dotnet format --verify-no-changes razor-pages/Web/ && \
 	dotnet format --verify-no-changes razor-pages/Core/
 
+hadolint-docker-linter: # runs as a docker container itself
+	printf "\n\n Running Docker linter...\n" && \
+	DOCKERFILES="$$(find . -type f \( -name 'Dockerfile' -o -name 'Dockerfile-*' -o -name '*.Dockerfile' \) -not -path './.git/*')" && \
+	if [ -z "$$DOCKERFILES" ]; then \
+		echo "No Dockerfiles found."; \
+		exit 0; \
+	fi && \
+	for dockerfile in $$DOCKERFILES; do \
+		echo "Linting $$dockerfile"; \
+		cat "$$dockerfile" | docker run --rm -i hadolint/hadolint; \
+	done
+
+meziantou-c-sharp-analyzer:
+
+
 test-all: test-ui-selenium test-api-simulator
-lint-all: lint-spell-checker lint-c-sharp
+lint-all: spell-checker c-sharp-code-formatter meziantou-c-sharp-analyzer hadolint-docker-linter
 run-all-validations: test-all lint-all
 
 build-and-test: # requires API_TOKEN to be set in environment variable API_TOKEN

--- a/README.md
+++ b/README.md
@@ -134,6 +134,6 @@ An alternative strategy is blue-green deployment, which provides instant rollbac
 
 We use the following static analysis tools in our CI pipelines to improve code quality. None of these tools modifies code on their own; however, pull requests don't pass the quality gate if one of them issues errors.
 - **Dotnet Format**, a build-in .NET SDK code formatter. We use the default rules from the SDK-provided .editorconfig files to format our C# code in the `razor-pages` folder. If a pull request doesn't follow these rules, the tools issues an error and fails the CI pipeline. `make auto-lint` can be run to fix the errors, but it's not run on its own against the project repository.
-- **Meziantou.Analyzer**, a Roslyn analyzer that detects bugs, security issues, and best practices violations. 
+- **Roslynator**, a Roslyn-based analyzer (meaning deep understanding of C#) that detects bugs, security issues, and violations of best practices. Set to `--severity-level=warning` to limit the amount of diagnostics it produces by default. 
 - **Codespell**, a general spell-checker, ensuring the right spelling of common words within the entire codebase. Fails the pipeline if it finds errors such as "teh" ==> "the".
-- **Hadolint**, a Docker linter. Scans the repository for Dockerfiles, then runs the linter against each. 
+- **Hadolint**, a Docker linter. Scans the repository for Dockerfiles, then runs the linter against each. Runs with default `failure-threshold=info`.

--- a/README.md
+++ b/README.md
@@ -129,3 +129,11 @@ Rolling updates are simple and efficient but they come with some limitations:
 #### Why not Blue-Green Deployment?
 
 An alternative strategy is blue-green deployment, which provides instant rollback and avoids running mixed versions. However, it requires maintaining two identical systems and to switch traffic between them. Given our setup and project scope, this added complexity is not worth it
+
+### Choice of Static Analysis Tools
+
+We use the following static analysis tools in our CI pipelines to improve code quality. None of these tools modifies code on their own; however, pull requests don't pass the quality gate if one of them issues errors.
+- **Dotnet Format**, a build-in .NET SDK code formatter. We use the default rules from the SDK-provided .editorconfig files to format our C# code in the `razor-pages` folder. If a pull request doesn't follow these rules, the tools issues an error and fails the CI pipeline. `make auto-lint` can be run to fix the errors, but it's not run on its own against the project repository.
+- **Meziantou.Analyzer**, a Roslyn analyzer that detects bugs, security issues, and best practices violations. 
+- **Codespell**, a general spell-checker, ensuring the right spelling of common words within the entire codebase. Fails the pipeline if it finds errors such as "teh" ==> "the".
+- **Hadolint**, a Docker linter. Scans the repository for Dockerfiles, then runs the linter against each. 

--- a/log.md
+++ b/log.md
@@ -80,3 +80,4 @@
 * Added additional debug printouts to `test-api-simulator`
 ### Week 13 (May 1 - May 6)
 * Added `.mailmap` file to consolidate authors into persons
+* Added two new static analysis tool to `continuous-QA-deployment`, `hadolint` for testing the linting of Dockerfiles and Roslynator for analyzing the C# code. 

--- a/razor-pages/Dockerfile
+++ b/razor-pages/Dockerfile
@@ -1,6 +1,6 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
-RUN mkdir -p /app/keys && chown -R $APP_UID:$APP_UID /app/keys && chmod 700 /app/keys
+RUN mkdir -p /app/keys && chown -R "$APP_UID:$APP_UID" /app/keys && chmod 700 /app/keys
 
 USER $APP_UID
 EXPOSE 8080
@@ -26,6 +26,6 @@ FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 USER root
-RUN chown -R $APP_UID:$APP_UID /app
+RUN chown -R "$APP_UID:$APP_UID" /app
 USER $APP_UID
 ENTRYPOINT ["dotnet", "Web.dll"]

--- a/tests/selenium/Dockerfile
+++ b/tests/selenium/Dockerfile
@@ -1,8 +1,9 @@
 # slim is a minimal python installation
 FROM python:3.12-slim 
 
+WORKDIR /tests/selenium
 COPY requirements.txt .
-RUN pip install --only-binary :all: --require-hashes -r requirements.txt && useradd appuser
+RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements.txt && useradd appuser
 
 WORKDIR /tests
 RUN chown appuser:appuser /tests


### PR DESCRIPTION
# Description

This pull request add two new static analysis tools to our QA workflow, hadolint for docker linting and Roslynator for advanced C# code analysis. It also applies hadolint-suggested changes to Dockerfiles. 

This makes us hit the three required tools: a code formatter, a linter and a second linter for Docker. 

# Checklist:

- [x] This PR represents one logical change to the codebase
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I updated `log.md` and/or `README.md` with relevant usage notes and choice documentation
- [x] **(If DB changes)** I have tested the migration end-to-end locally and noted any pitfalls and expected downtime
- [x] **(If deployment/monitoring workflows changed)** Required secrets and env vars are documented; workflow behaviour is as expected
- [x] No secrets, API keys, or credentials are committed (only env examples or placeholders)
