### PR TITLE
Chore: Idempotence ✨

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,23 +19,37 @@ app-down-build: # Delete all volumes and rebuild the app
 install-ef-tools:
 	dotnet tool install --global dotnet-ef
 
-# Database Migrations from root directory
-db-migrate:
-	dotnet ef migrations add $(name) \
+# Database Migrations from root directory unless a migration with same name exists
+db-migrate: 
+	@if dotnet ef migrations list \
 		--context MiniTwitContext \
 		--project razor-pages/Infrastructure \
-		--startup-project razor-pages/Web && \
+		--startup-project razor-pages/Web | grep -q "$(name)"; then \
+		echo "Migration '$(name)' already exists. Skipping add."; \
+	else \
+		dotnet ef migrations add $(name) \
+			--context MiniTwitContext \
+			--project razor-pages/Infrastructure \
+			--startup-project razor-pages/Web; \
+	fi && \
 	dotnet ef database update \
-    	--context MiniTwitContext \
-    	--project razor-pages/Infrastructure \
-    	--startup-project razor-pages/Web
-
-# Database remove migrations from root directory
-db-remove-migration:
-	dotnet ef migrations remove \
 		--context MiniTwitContext \
 		--project razor-pages/Infrastructure \
 		--startup-project razor-pages/Web
+
+# Database remove migrations from root directory if any exist
+db-remove-migration:
+	@if dotnet ef migrations list \
+		--context MiniTwitContext \
+		--project razor-pages/Infrastructure \
+		--startup-project razor-pages/Web | grep -q "No migrations were found"; then \
+		echo "No migrations to remove."; \
+	else \
+		dotnet ef migrations remove --force \
+			--context MiniTwitContext \
+			--project razor-pages/Infrastructure \
+			--startup-project razor-pages/Web; \
+	fi
 
 # Database Migration Update from root directory
 db-update:

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,11 @@ provision-digital-ocean:
 	vagrant provision
 
 clean-digital-ocean:
-	vagrant destroy && \
+	@if vagrant status | grep -q 'webserver.*running'; then \
+		vagrant destroy -f; \
+	else \
+		echo "Vagrant VM 'webserver' is not running."; \
+	fi && \
 	rm -rf .vagrant
 
 # Monitoring stack (Loki on monitoring VM; Promtail ships with root compose on app VM)

--- a/README.md
+++ b/README.md
@@ -137,3 +137,19 @@ We use the following static analysis tools in our CI pipelines to improve code q
 - **Roslynator**, a Roslyn-based analyzer (meaning deep understanding of C#) that detects bugs, security issues, and violations of best practices. Set to `--severity-level=warning` to limit the amount of diagnostics it produces by default. 
 - **Codespell**, a general spell-checker, ensuring the right spelling of common words within the entire codebase. Fails the pipeline if it finds errors such as "teh" ==> "the".
 - **Hadolint**, a Docker linter. Scans the repository for Dockerfiles, then runs the linter against each. Runs with default `failure-threshold=info`.
+
+### Idempotence in Configuration Files
+
+We have analyzed the Vagrantfiles, the Dockerfile and the Makefile for idempotence issues. We decided against migrating our solution to an external tool like Ansible for simplicity.Dockerfiles only required small fixes related to potential double user creation. We found no issues in the Vagrantfiles provisioning — if something is reinstalled or rebuilt but the system ends up in the same state without throwing an error, we don't consider that a problem. 
+
+The Makefile required most effort to analyze. We defined the desired quality to be a consistent state and the absence of errors if a command runs repeatedly, provided all the prerequisites (such as *environment variables*) are met. 
+
+We applied changes to migration recipes `db-migrate` and `db-remove-migration` as they had thrown errors if executed repeatedly. If a package is already present, `dotnet tool install` reports it but succeeds, so we left it as is. Similarly, `pip install` will reinstall, but not fail. All validation recipes can be run repeatedly with the same effect. `Vagrant up` is idempotent, as per the following documentation snippet:
+
+>If the virtual machine already exists and you run vagrant up again, Vagrant will start the machine without running the provisioning scripts. If you modify your provisioning scripts or need to reapply them, use vagrant provision or --provision. This re-runs all provisioning scripts in your Vagrantfile to apply updates or fixes.
+
+`Vagrant destroy` had thrown an error if executed repeatedly, so we added a guard check. `docker compose up` is designed to be idempotent, as per the following (it does nothing if nothing was changed): 
+
+>If there are existing containers for a service, and the service’s configuration or image was changed after the container’s creation, docker compose up picks up the changes by stopping and recreating the containers (preserving mounted volumes).
+
+`API-generate` generates the same stub each time it runs, overwriting the previous one. The container exits immediately after completion, so there is no risk of multiple leftover containers running.

--- a/log.md
+++ b/log.md
@@ -81,3 +81,4 @@
 ### Week 13 (May 1 - May 6)
 * Added `.mailmap` file to consolidate authors into persons
 * Added two new static analysis tool to `continuous-QA-deployment`, `hadolint` for testing the linting of Dockerfiles and Roslynator for analyzing the C# code. 
+* Reviewed the idempotence of our configuration files. Applied small changes to both Dockerfiles; reviewed both Vagrantfiles but found no issues; applied changes to the Makefile; updated the readme.

--- a/razor-pages/Dockerfile
+++ b/razor-pages/Dockerfile
@@ -1,4 +1,8 @@
 ﻿FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+
+# Bake in the APP_UID explicitly instead of inheriting this value from the online image
+ENV APP_UID=1654
+
 WORKDIR /app
 RUN mkdir -p /app/keys && chown -R "$APP_UID:$APP_UID" /app/keys && chmod 700 /app/keys
 

--- a/tests/selenium/Dockerfile
+++ b/tests/selenium/Dockerfile
@@ -1,13 +1,14 @@
 # slim is a minimal python installation
 FROM python:3.12-slim 
 
-WORKDIR /tests/selenium
-COPY requirements.txt .
-RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements.txt && useradd appuser
-
 WORKDIR /tests
-RUN chown appuser:appuser /tests
+COPY requirements.txt .
+RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements.txt 
+
+# create a user if doesn't exist, grant permissions
+RUN (id appuser >/dev/null 2>&1 || useradd appuser) && chown appuser:appuser /tests
 COPY --chown=root:root --chmod=755 test_itu_minitwit_ui.py .
+
 USER appuser
 CMD ["pytest", "test_itu_minitwit_ui.py"]
 

--- a/tests/selenium/Dockerfile
+++ b/tests/selenium/Dockerfile
@@ -3,10 +3,10 @@ FROM python:3.12-slim
 
 WORKDIR /tests
 COPY requirements.txt .
-RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements.txt 
-
+RUN pip install --no-cache-dir --only-binary :all: --require-hashes -r requirements.txt \
 # create a user if doesn't exist, grant permissions
-RUN (id appuser >/dev/null 2>&1 || useradd appuser) && chown appuser:appuser /tests
+&& (id appuser >/dev/null 2>&1 || useradd appuser) && chown appuser:appuser /tests
+
 COPY --chown=root:root --chmod=755 test_itu_minitwit_ui.py .
 
 USER appuser


### PR DESCRIPTION
# Description

A chore to make all configuration files idempotent (Vagrantfile, Dockerfile, Makefile). We decided against using an additional tool like Ansible for simplicity, instead preferring to add idempotence-reviewed code directly to our source files. 

# Checklist:

- [x] This PR represents one logical change to the codebase
- [x] I have performed a self-review of my own code
- [x] <s>I have added tests that prove my fix is effective or that my feature works</s> -> I have run each makefile recipe I meddled with to verify if it has the desired functionality in both scenarios, save for a successful vagrant destroy for obvious reasons.
- [x] I updated `log.md` and/or `README.md` with relevant usage notes and choice documentation
- [ ] **(If DB changes)** I have tested the migration end-to-end locally and noted any pitfalls and expected downtime
- [ ] **(If deployment/monitoring workflows changed)** Required secrets and env vars are documented; workflow behaviour is as expected
- [x] No secrets, API keys, or credentials are committed (only env examples or placeholders)
