### PR TITLE
Bug: Changed dockerscout to scan the exact image that was built

### DIFF
--- a/.github/workflows/continous-QA-deployment.yaml
+++ b/.github/workflows/continous-QA-deployment.yaml
@@ -111,6 +111,22 @@ jobs:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST_TEST }}
 
+      - name: Install Docker Scout CLI
+        run: |
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            https://raw.githubusercontent.com/docker/scout-cli/main/install.sh \
+            -o install-scout.sh
+
+          docker scout version
+
+      - name: Run Docker Scout CVE scan (SHIFT-LEFT)
+        run: |
+          docker scout cves $DOCKER_USERNAME/minitwitimage:${{ github.sha }} \
+          --only-severity critical,high \
+          --exit-code
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+
       - name: Deploy to server (using compose)
         run: >
           ssh $SSH_USER@$SSH_HOST

--- a/.github/workflows/continous-QA-deployment.yaml
+++ b/.github/workflows/continous-QA-deployment.yaml
@@ -117,6 +117,8 @@ jobs:
             https://raw.githubusercontent.com/docker/scout-cli/main/install.sh \
             -o install-scout.sh
 
+          sh install-scout.sh
+
           docker scout version
 
       - name: Run Docker Scout CVE scan (SHIFT-LEFT)

--- a/.github/workflows/continous-QA-deployment.yaml
+++ b/.github/workflows/continous-QA-deployment.yaml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Run Docker Scout CVE scan (SHIFT-LEFT)
         run: |
-          docker scout cves $DOCKER_USERNAME/minitwitimage:${{ github.sha }} \
+          docker scout cves $DOCKER_USERNAME/testminitwit:latest \
           --only-severity critical,high \
           --exit-code
         env:

--- a/.github/workflows/continous-deployment.yaml
+++ b/.github/workflows/continous-deployment.yaml
@@ -97,22 +97,6 @@ jobs:
           SSH_HOST_TEST: ${{ secrets.SSH_HOST_TEST }}
           MONITOR_SSH_HOST: ${{ secrets.MONITOR_SSH_HOST }}
 
-      - name: Install Docker Scout CLI
-        run: |
-          curl --proto '=https' --tlsv1.2 -fsSL \
-            https://raw.githubusercontent.com/docker/scout-cli/main/install.sh \
-            -o install-scout.sh
-
-          docker scout version
-
-      - name: Run Docker Scout CVE scan (SHIFT-LEFT)
-        run: |
-          docker scout cves $DOCKER_USERNAME/minitwitimage:${{ github.sha }} \
-          --only-severity critical,high \
-          --exit-code
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-
       - name: Deploy to server (using compose)
         run: >
           ssh $SSH_USER@$SSH_HOST -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no

--- a/.github/workflows/continous-deployment.yaml
+++ b/.github/workflows/continous-deployment.yaml
@@ -97,15 +97,10 @@ jobs:
           SSH_HOST_TEST: ${{ secrets.SSH_HOST_TEST }}
           MONITOR_SSH_HOST: ${{ secrets.MONITOR_SSH_HOST }}
 
-      - name: Install Docker Scout CLI (SonarQube safe)
+      - name: Install Docker Scout CLI
         run: |
-          mkdir -p $HOME/.docker/cli-plugins
-
-          curl --proto "=https" --tlsv1.2 -sSf -L \
-            https://github.com/docker/scout-cli/releases/latest/download/docker-scout-linux-amd64 \
-            -o $HOME/.docker/cli-plugins/docker-scout
-
-          chmod +x $HOME/.docker/cli-plugins/docker-scout
+          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh -o install-scout.sh
+          sh install-scout.sh
 
           docker scout version
 

--- a/.github/workflows/continous-deployment.yaml
+++ b/.github/workflows/continous-deployment.yaml
@@ -106,9 +106,11 @@ jobs:
 
       - name: Run Docker Scout CVE scan (SHIFT-LEFT)
         run: |
-          docker scout cves minitwit-app:latest \
-            --only-severity critical,high \
-            --exit-code
+          docker scout cves $DOCKER_USERNAME/minitwitimage:${{ github.sha }} \
+          --only-severity critical,high \
+          --exit-code
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
       - name: Deploy to server (using compose)
         run: >

--- a/.github/workflows/continous-deployment.yaml
+++ b/.github/workflows/continous-deployment.yaml
@@ -99,8 +99,9 @@ jobs:
 
       - name: Install Docker Scout CLI
         run: |
-          curl -fsSL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh -o install-scout.sh
-          sh install-scout.sh
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            https://raw.githubusercontent.com/docker/scout-cli/main/install.sh \
+            -o install-scout.sh
 
           docker scout version
 


### PR DESCRIPTION
# Description
changed Scout to scan the exact image that was actually built
<!--- Please include a summary of the change. Should be understandable even for someone who does not know the codebase-->
<!--- Please include relevant motivation and context. Any choices should also be documented in relevant .md files -->

# Checklist:

- [x] This PR represents one logical change to the codebase
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I updated `log.md` and/or `README.md` with relevant usage notes and choice documentation
- [x] **(If DB changes)** I have tested the migration end-to-end locally and noted any pitfalls and expected downtime
- [x] **(If deployment/monitoring workflows changed)** Required secrets and env vars are documented; workflow behaviour is as expected
- [x] No secrets, API keys, or credentials are committed (only env examples or placeholders)
