### PR TITLE
Test: Refactor Minitwit Integration Test to C#

### DIFF
--- a/razor-pages/Web.Tests/BasicTests.cs
+++ b/razor-pages/Web.Tests/BasicTests.cs
@@ -1,0 +1,167 @@
+﻿using Xunit;
+using Infrastructure.Repositories;
+using Infrastructure.Context;
+using Microsoft.EntityFrameworkCore;
+using System;
+using Microsoft.Extensions.Configuration;
+using DotNetEnv;
+
+namespace Web.Tests;
+
+// TODO: seems like dotnet test still doesn't detect this suite?
+
+public class BasicTests
+{
+    private readonly MiniTwitContext _context;
+    private readonly UserRepository _userRepo;
+    private readonly MessageRepository _messageRepo;
+    private readonly FollowerRepository _followerRepo;
+
+    public BasicTests()
+    {
+        // Load .env like the main app if present
+        if (File.Exists(Path.Combine(Directory.GetCurrentDirectory(), ".env")))
+        {
+            Env.Load();
+        }
+
+        // This registers the environment variables as configuration source, meaning CONNECTIONSTRINGS__TESTCONNECTION
+        // will be possible to read as ConnectionStrings:TESTCONNECTION later
+        var config = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .Build();
+
+        var connStr = config.GetConnectionString("TESTCONNECTION");
+
+        // Npgsql takes care of translation from LINQ to PostgreSQL
+        var options = new DbContextOptionsBuilder<MiniTwitContext>()
+            .UseNpgsql(connStr)
+            .Options;
+
+        // You pass the options object, in this case containing the connStr setting, to context
+        _context = new MiniTwitContext(options);
+
+        // Create Repository objects from context with built-in methods instead of python helpers
+        _userRepo = new UserRepository(_context);
+        _messageRepo = new MessageRepository(_context);
+        _followerRepo = new FollowerRepository(_context);
+
+        // Ensure a clean database state for each test by truncating relevant tables 
+        // (it might not be the minimal set of tables, I'm not sure) <- TODO
+        // SimulatorLatest is omitted as it's only valid for API calls which these tests don't do
+        _context.Database.ExecuteSqlRaw(@"
+            TRUNCATE TABLE
+            ""Followers"",
+            ""Messages"",
+            ""AspNetUserTokens"",
+            ""AspNetUserRoles"",
+            ""AspNetUserLogins"",
+            ""AspNetUserClaims"",
+            ""AspNetUsers""
+            RESTART IDENTITY CASCADE;
+            ");
+    }
+
+    [Fact]
+    public void Register_User_Works()
+    {
+        var username = "user1";
+        var password = "default";
+        var email = "user1@example.com";
+        _userRepo.CreateUser(username, email, password);
+        var user = _userRepo.GetUserByUsername(username);
+
+        // Check if the registration succeeded
+        Assert.NotNull(user);
+        Assert.Equal(username, user.UserName);
+
+        // Try to register same user again
+        Assert.Throws<ArgumentException>(() => _userRepo.CreateUser(username, email, password));
+    }
+
+    [Fact]
+    public void Register_Validation_Works()
+    {
+        // Empty username TODO: can I throw specific Exceptions like in python code?
+        Assert.Throws<ArgumentException>(() => _userRepo.CreateUser("", "test@example.com", "pw"));
+        // Empty password
+        Assert.Throws<ArgumentException>(() => _userRepo.CreateUser("meh", "meh@example.com", ""));
+        // TODO: 
+        // Copilot hint: Password mismatch and email validation would be handled in service/controller, not repo
+    }
+
+    [Fact]
+    public void Login_Logout_Works()
+    {
+        var username = "user1";
+        var password = "default";
+        var email = "user1@example.com";
+        _userRepo.CreateUser(username, email, password);
+
+        // Login success
+        var user = _userRepo.Login(username, password);
+        Assert.NotNull(user);
+
+        // Login wrong password
+        var userWrongPw = _userRepo.Login(username, "wrongpassword");
+        Assert.Null(userWrongPw);
+
+        // Login wrong username
+        var userWrongUser = _userRepo.Login("user2", "wrongpassword");
+        Assert.Null(userWrongUser);
+    }
+
+    [Fact]
+    public void Message_Recording_Works()
+    {
+        var username = "foo";
+        var password = "default";
+        var email = "foo@example.com";
+        _userRepo.CreateUser(username, email, password);
+        var user = _userRepo.Login(username, password);
+        Assert.NotNull(user);
+
+        _messageRepo.CreateMessage(user.Id, "test message 1");
+        _messageRepo.CreateMessage(user.Id, "<test message 2>");
+
+        var timeline = _messageRepo.GetUserTimeline(user.Id);
+        Assert.Contains(timeline, m => m.Text == "test message 1");
+        Assert.Contains(timeline, m => m.Text == "<test message 2>");
+    }
+
+    [Fact]
+    public void Timelines_Work()
+    {
+        // foo posts
+        _userRepo.CreateUser("foo", "foo@example.com", "default");
+        var foo = _userRepo.Login("foo", "default");
+        _messageRepo.CreateMessage(foo.Id, "the message by foo");
+
+        // bar posts
+        _userRepo.CreateUser("bar", "bar@example.com", "default");
+        var bar = _userRepo.Login("bar", "default");
+        _messageRepo.CreateMessage(bar.Id, "the message by bar");
+
+        // Public timeline
+        var publicTimeline = _messageRepo.GetPublicTimeline();
+        Assert.Contains(publicTimeline, m => m.Text == "the message by foo");
+        Assert.Contains(publicTimeline, m => m.Text == "the message by bar");
+
+        // bar's timeline should just show bar's message
+        var barTimeline = _messageRepo.GetUserTimeline(bar.Id);
+        Assert.DoesNotContain(barTimeline, m => m.Text == "the message by foo");
+        Assert.Contains(barTimeline, m => m.Text == "the message by bar");
+
+        // bar follows foo
+        _followerRepo.FollowUser(bar.Id, foo.Id);
+        var myTimeline = _messageRepo.GetMyTimeline(bar.Id);
+        Assert.Contains(myTimeline, m => m.Text == "the message by foo");
+        Assert.Contains(myTimeline, m => m.Text == "the message by bar");
+
+        // Unfollow foo
+        _followerRepo.UnfollowUser(bar.Id, foo.Id);
+        var myTimelineAfterUnfollow = _messageRepo.GetMyTimeline(bar.Id);
+        Assert.DoesNotContain(myTimelineAfterUnfollow, m => m.Text == "the message by foo");
+        Assert.Contains(myTimelineAfterUnfollow, m => m.Text == "the message by bar");
+    }
+}

--- a/razor-pages/Web.Tests/Web.Tests.csproj
+++ b/razor-pages/Web.Tests/Web.Tests.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/razor-pages/Web/Program.cs
+++ b/razor-pages/Web/Program.cs
@@ -88,3 +88,5 @@ app.MapRazorPages()
     .WithStaticAssets();
 
 app.Run();
+
+public partial class Program { }

--- a/razor-pages/Web/Web.csproj
+++ b/razor-pages/Web/Web.csproj
@@ -36,5 +36,9 @@
         <ProjectReference Include="..\Core\Core.csproj" />
         <ProjectReference Include="..\Infrastructure\Infrastructure.csproj" />
     </ItemGroup>
+
+    <ItemGroup>
+     <InternalsVisibleTo Include="Web.Tests" />
+    </ItemGroup>
     
 </Project>

--- a/tests/minitwit_tests.py
+++ b/tests/minitwit_tests.py
@@ -1,0 +1,145 @@
+# -*- coding: utf-8 -*-
+"""
+    MiniTwit Tests
+    ~~~~~~~~~~~~~~
+
+    Tests the MiniTwit application.
+
+    :copyright: (c) 2010 by Armin Ronacher.
+    :license: BSD, see LICENSE for more details.
+"""
+from __future__ import absolute_import
+import minitwit
+import unittest
+import tempfile
+
+
+class MiniTwitTestCase(unittest.TestCase):
+
+    def setUp(self):
+        """Before each test, set up a blank database"""
+        self.db = tempfile.NamedTemporaryFile()
+        self.app = minitwit.app.test_client()
+        minitwit.DATABASE = self.db.name
+        minitwit.init_db()
+
+    # helper functions
+
+    def register(self, username, password, password2=None, email=None):
+        """Helper function to register a user"""
+        if password2 is None:
+            password2 = password
+        if email is None:
+            email = username + '@example.com'
+        return self.app.post('/register', data={
+            'username':     username,
+            'password':     password,
+            'password2':    password2,
+            'email':        email,
+        }, follow_redirects=True)
+
+    def login(self, username, password):
+        """Helper function to login"""
+        return self.app.post('/login', data={
+            'username': username,
+            'password': password
+        }, follow_redirects=True)
+
+    def register_and_login(self, username, password):
+        """Registers and logs in in one go"""
+        self.register(username, password)
+        return self.login(username, password)
+
+    def logout(self):
+        """Helper function to logout"""
+        return self.app.get('/logout', follow_redirects=True)
+
+    def add_message(self, text):
+        """Records a message"""
+        rv = self.app.post('/add_message', data={'text': text},
+                                    follow_redirects=True)
+        if text:
+            assert 'Your message was recorded' in rv.data.decode()
+        return rv
+
+    # testing functions
+
+    def test_register(self):
+        """Make sure registering works"""
+        rv = self.register('user1', 'default')
+        assert 'You were successfully registered ' \
+               'and can login now' in rv.data.decode() # this rv is the response of a test_client which is app
+        rv = self.register('user1', 'default')
+        assert 'The username is already taken' in rv.data.decode()
+        rv = self.register('', 'default')
+        assert 'You have to enter a username' in rv.data.decode()
+        rv = self.register('meh', '')
+        assert 'You have to enter a password' in rv.data.decode()
+        rv = self.register('meh', 'x', 'y')
+        assert 'The two passwords do not match' in rv.data.decode()
+        rv = self.register('meh', 'foo', email='broken')
+        assert 'You have to enter a valid email address' in rv.data.decode()
+
+    def test_login_logout(self):
+        """Make sure logging in and logging out works"""
+        rv = self.register_and_login('user1', 'default')
+        assert 'You were logged in' in rv.data.decode()
+        rv = self.logout()
+        assert 'You were logged out' in rv.data.decode()
+        rv = self.login('user1', 'wrongpassword')
+        assert 'Invalid password' in rv.data.decode()
+        rv = self.login('user2', 'wrongpassword')
+        assert 'Invalid username' in rv.data.decode()
+
+    def test_message_recording(self):
+        """Check if adding messages works"""
+        self.register_and_login('foo', 'default')
+        self.add_message('test message 1')
+        self.add_message('<test message 2>')
+        rv = self.app.get('/')
+        assert 'test message 1' in rv.data.decode()
+        assert '&lt;test message 2&gt;' in rv.data.decode()
+
+    def test_timelines(self):
+        """Make sure that timelines work"""
+        self.register_and_login('foo', 'default')
+        self.add_message('the message by foo')
+        self.logout()
+        self.register_and_login('bar', 'default')
+        self.add_message('the message by bar')
+        rv = self.app.get('/public')
+        assert 'the message by foo' in rv.data.decode()
+        assert 'the message by bar' in rv.data.decode()
+
+        # bar's timeline should just show bar's message
+        rv = self.app.get('/')
+        assert 'the message by foo' not in rv.data.decode()
+        assert 'the message by bar' in rv.data.decode()
+
+        # now let's follow foo
+        rv = self.app.get('/foo/follow', follow_redirects=True)
+        assert 'You are now following &#34;foo&#34;' in rv.data.decode()
+
+        # we should now see foo's message
+        rv = self.app.get('/')
+        assert 'the message by foo' in rv.data.decode()
+        assert 'the message by bar' in rv.data.decode()
+
+        # but on the user's page we only want the user's message
+        rv = self.app.get('/bar')
+        assert 'the message by foo' not in rv.data.decode()
+        assert 'the message by bar' in rv.data.decode()
+        rv = self.app.get('/foo')
+        assert 'the message by foo' in rv.data.decode()
+        assert 'the message by bar' not in rv.data.decode()
+
+        # now unfollow and check if that worked
+        rv = self.app.get('/foo/unfollow', follow_redirects=True)
+        assert 'You are no longer following &#34;foo&#34;' in rv.data.decode()
+        rv = self.app.get('/')
+        assert 'the message by foo' not in rv.data.decode()
+        assert 'the message by bar' in rv.data.decode()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Description

This is an unarchived task to refactor minitwit_test.py to a valid C# test suite. It serves as a bridge to the implementation of an end-to-end test in the continuous-QA-deployment workflow. 

# Checklist:

- [ ] This PR represents one logical change to the codebase
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I updated `log.md` and/or `README.md` with relevant usage notes and choice documentation
- [ ] **(If DB changes)** I have tested the migration end-to-end locally and noted any pitfalls and expected downtime
- [ ] **(If deployment/monitoring workflows changed)** Required secrets and env vars are documented; workflow behaviour is as expected
- [ ] No secrets, API keys, or credentials are committed (only env examples or placeholders)
