### PR TITLE
Bug: add variable to specify storage size 🐛

### DIFF
--- a/infrastructure/modules/do-postgres-db/main.tf
+++ b/infrastructure/modules/do-postgres-db/main.tf
@@ -1,10 +1,11 @@
 resource "digitalocean_database_cluster" "postgres-db" {
-  name       = var.name
-  engine     = var.engine
-  version    = var.engine_version
-  size       = var.size
-  region     = var.region
-  node_count = var.node_count
+  name               = var.name
+  engine             = var.engine
+  version            = var.engine_version
+  size               = var.size
+  region             = var.region
+  node_count         = var.node_count
+  storage_size_mib   = var.storage_size_mib
 }
 
 resource "digitalocean_database_firewall" "droplet-firewall" {

--- a/infrastructure/modules/do-postgres-db/variables.tf
+++ b/infrastructure/modules/do-postgres-db/variables.tf
@@ -33,6 +33,13 @@ variable "node_count" {
   default     = 1
 }
 
+# Disk is per SKU; e.g. db-s-1vcpu-1gb allows 10–50 GiB. 61440 MiB (60 GiB) is rejected by the API.
+variable "storage_size_mib" {
+  type        = number
+  description = "Primary storage in MiB (mebibytes). Must be within the min/max GiB range for the chosen size slug (see DigitalOcean managed DB docs)."
+  default     = 51200 # 50 GiB — typical maximum for db-s-1vcpu-1gb
+}
+
 variable "droplet_firewall_entries" {
   type        = map(string)
   description = "Static-key map of droplet IDs for managed-database firewall rules (keys must be known at plan time)."


### PR DESCRIPTION
# Description

This PR fixes that the database size needs to be resized when the cluster is resized by addign a variable allowing to do so.
