### PR TITLE
Bug: Loki environment name mismatch

### DIFF
--- a/.github/workflows/continous-QA-deployment.yaml
+++ b/.github/workflows/continous-QA-deployment.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "API_TOKEN=$API_TOKEN" > razor-pages/Web/.env
           echo "CONNECTIONSTRINGS__DEFAULTCONNECTION=$CONNECTIONSTRING" >> razor-pages/Web/.env
-          echo "LOKI_URL=$LOKI_URL" > promtail/.env
+          echo "PROD_LOKI_URL=$LOKI_URL" > promtail/.env
         env:
           API_TOKEN: ${{ secrets.API_TOKEN }}
           CONNECTIONSTRING: ${{ secrets.TESTCONNECTIONSTRING }}

--- a/.github/workflows/continous-QA-deployment.yaml
+++ b/.github/workflows/continous-QA-deployment.yaml
@@ -52,7 +52,7 @@ jobs:
         run: |
           echo "API_TOKEN=$API_TOKEN" > razor-pages/Web/.env
           echo "CONNECTIONSTRINGS__DEFAULTCONNECTION=$CONNECTIONSTRING" >> razor-pages/Web/.env
-          echo "PROD_LOKI_URL=$LOKI_URL" > promtail/.env
+          echo "LOKI_URL=$LOKI_URL" > promtail/.env
         env:
           API_TOKEN: ${{ secrets.API_TOKEN }}
           CONNECTIONSTRING: ${{ secrets.TESTCONNECTIONSTRING }}

--- a/.github/workflows/continous-deployment.yaml
+++ b/.github/workflows/continous-deployment.yaml
@@ -108,7 +108,7 @@ jobs:
            export IMAGE_TAG='${{ github.sha }}' && 
            export API_TOKEN='"$API_TOKEN"' &&
            export CONNECTIONSTRING='"$CONNECTIONSTRING"' &&
-           export PROD_LOKI_URL='"$PROD_LOKI_URL"' &&
+           export LOKI_URL='"$PROD_LOKI_URL"' &&
            cd /vagrant &&  
            docker stack deploy --with-registry-auth --resolve-image always -c compose.yaml minitwit"
         env:

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,7 +13,7 @@ services:
       - ISLOCALDEVELOPMENT=${ISLOCALDEVELOPMENT:-false}
       - CONNECTIONSTRINGS__DEFAULTCONNECTION=${CONNECTIONSTRING}
       - API_TOKEN=${API_TOKEN}
-      - PROD_LOKI_URL=${PROD_LOKI_URL}
+      - LOKI_URL=${PROD_LOKI_URL}
       - DOCKER_USERNAME=${DOCKER_USERNAME}
     volumes:
       - keys-volume:/app/keys
@@ -30,7 +30,7 @@ services:
   promtail:
     image: grafana/promtail:3.6.7
     environment:
-      - PROD_LOKI_URL=${PROD_LOKI_URL}
+      - LOKI_URL=${PROD_LOKI_URL}
     volumes:
       - /vagrant/promtail/promtail-config.yaml:/etc/promtail/config.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/promtail/promtail-config.yaml
+++ b/promtail/promtail-config.yaml
@@ -7,7 +7,7 @@ positions:
   filename: /tmp/positions.yaml
 
 clients:
-  - url: ${PROD_LOKI_URL}
+  - url: ${LOKI_URL}
 
 scrape_configs:
   - job_name: docker


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change. Should be understandable even for someone who does not know the codebase-->
<!--- Please include relevant motivation and context. Any choices should also be documented in relevant .md files -->

- The Loki DEV did not show any logs on Grafana due to environment name mismatch (e.g. the Promtail looked for PROD_LOKI_URL but the secret in .env file was called LOKI_URL)
- I renamed the environment name to LOKI_URL to generalize it for the PROD and DEV. 
- The right Loki logs should be displayed for PROD and DEV as they use PROD_LOKI_URL and QA_LOKI_URL accordingly. 
- I have tested it for QA which now displays the logs http://209.38.255.154:3000/d/ad8t4bq/logging-dev?orgId=1&from=now-15m&to=now&timezone=browser. 

# Checklist:

- [x] This PR represents one logical change to the codebase
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I updated `log.md` and/or `README.md` with relevant usage notes and choice documentation
- [ ] **(If DB changes)** I have tested the migration end-to-end locally and noted any pitfalls and expected downtime
- [x] **(If deployment/monitoring workflows changed)** Required secrets and env vars are documented; workflow behaviour is as expected
- [x] No secrets, API keys, or credentials are committed (only env examples or placeholders)
